### PR TITLE
Add SURFBEE_G071 workflow

### DIFF
--- a/.github/workflows/surfbee.yml
+++ b/.github/workflows/surfbee.yml
@@ -1,0 +1,33 @@
+name: Build SURFBEE_G071
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v1
+
+      - name: Install ARM SDK
+        run: make arm_sdk_install
+
+      - name: Build SURFBEE_G071
+        run: make SURFBEE_G071
+
+      - name: Upload Bin File
+        uses: actions/upload-artifact@v2
+        with:
+          name: SURFBEE_G071-bin
+          path: obj/*SURFBEE_G071*.bin
+
+      - name: Upload Hex File
+        uses: actions/upload-artifact@v2
+        with:
+          name: SURFBEE_G071-hex
+          path: obj/*SURFBEE_G071*.hex


### PR DESCRIPTION
## Summary
- add `surfbee.yml` to build the SURFBEE_G071 target via GitHub Actions

## Testing
- `make SURFBEE_G071` *(fails: arm-none-eabi-gcc not in the PATH)*

------
https://chatgpt.com/codex/tasks/task_b_684fa10896cc83248c3e7230e15d75c6